### PR TITLE
Refactor RSSI indicator to have a title every time

### DIFF
--- a/res/MainToolbar/CustomRCRSSIIndicator.qml
+++ b/res/MainToolbar/CustomRCRSSIIndicator.qml
@@ -10,7 +10,6 @@
  */
 
 import QtQuick          2.11
-import QtQuick.Controls 1.4
 import QtQuick.Layouts  1.11
 
 import QGroundControl                       1.0
@@ -19,16 +18,14 @@ import QGroundControl.MultiVehicleManager   1.0
 import QGroundControl.ScreenTools           1.0
 import QGroundControl.Palette               1.0
 
-import Custom.Widgets                       1.0
-
 //-------------------------------------------------------------------------
 //-- RC RSSI Indicator
 Item {
-    id:                     _root
-    width:                  visible ? rssiRow.width : 0
-    anchors.top:            parent.top
-    anchors.bottom:         parent.bottom
-    visible:                activeVehicle ? activeVehicle.supportsRadio : true
+    id:             _root
+    width:          rssiRow.width * 1.1
+    anchors.top:    parent.top
+    anchors.bottom: parent.bottom
+    visible:        activeVehicle ? activeVehicle.supportsRadio : true
 
     property bool   _rcRSSIAvailable:   activeVehicle ? activeVehicle.rcRSSI > 0 && activeVehicle.rcRSSI <= 100 : false
 
@@ -40,19 +37,24 @@ Item {
             height: rcrssiCol.height  + ScreenTools.defaultFontPixelHeight * 2
             radius: ScreenTools.defaultFontPixelHeight * 0.5
             color:  qgcPal.window
+            border.color:   qgcPal.text
 
             Column {
                 id:                 rcrssiCol
                 spacing:            ScreenTools.defaultFontPixelHeight * 0.5
-                width:              Math.max(rcrssiGrid.width, rssiLabel.width)
                 anchors.margins:    ScreenTools.defaultFontPixelHeight
                 anchors.centerIn:   parent
 
                 QGCLabel {
                     id:             rssiLabel
-                    text:           activeVehicle ? (activeVehicle.rcRSSI !== 255 ? qsTr("RC RSSI Status") : qsTr("RC RSSI Data Unavailable")) : qsTr("N/A", "No data available")
+                    text:           qsTr("RC RSSI Status")
                     font.family:    ScreenTools.demiboldFontFamily
                     anchors.horizontalCenter: parent.horizontalCenter
+                }
+
+                QGCLabel {
+                    visible:        !rcrssiGrid.visible
+                    text:           activeVehicle ? qsTr("RC RSSI Data Unavailable") : qsTr("N/A", "No data available")
                 }
 
                 GridLayout {
@@ -74,20 +76,22 @@ Item {
         id:             rssiRow
         anchors.top:    parent.top
         anchors.bottom: parent.bottom
-        spacing:        ScreenTools.defaultFontPixelWidth * 0.25
+        spacing:        ScreenTools.defaultFontPixelWidth
+
         QGCColoredImage {
             width:              height
             anchors.top:        parent.top
             anchors.bottom:     parent.bottom
             sourceSize.height:  height
-            source:             "/custom/img/menu_rc.svg"
-            color:              qgcPal.text
+            source:             "/qmlimages/RC.svg"
             fillMode:           Image.PreserveAspectFit
             opacity:            _rcRSSIAvailable ? 1 : 0.5
+            color:              qgcPal.buttonText
         }
-        CustomSignalStrength {
+
+        SignalStrength {
             anchors.verticalCenter: parent.verticalCenter
-            size:                   parent.height * 0.75
+            size:                   parent.height * 0.5
             percent:                _rcRSSIAvailable ? activeVehicle.rcRSSI : 0
         }
     }

--- a/src/FirmwarePlugin/CustomFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/CustomFirmwarePlugin.cc
@@ -60,7 +60,7 @@ CustomFirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
 #endif
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")));
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")));
-        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/custom/CustomRCRSSIIndicator.qml")));
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")));
     }
     return _toolBarIndicatorList;


### PR DESCRIPTION
Fix overlapping with the close button in the following PR core PR: https://github.com/Auterion/qgroundcontrol/pull/11
Provide consistency in no RSSI state