### PR TITLE
Hide progress panel when user declines switch to high power mode

### DIFF
--- a/res/PairingIndicator.qml
+++ b/res/PairingIndicator.qml
@@ -309,6 +309,7 @@ Item {
         visible:            QGroundControl.pairingManager.confirmHighPowerMode;
         standardButtons:    StandardButton.Yes | StandardButton.No
         onNo: {
+            progressPopup.close()
             highPowerPrompt.close()
             runPairing()
         }


### PR DESCRIPTION
When user clicks NO on "Confirm High Power mode" then hide pairing progress panel.